### PR TITLE
Fix mobile menu and form selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,7 +645,8 @@
           <li><a href="#contact">Contact</a></li>
         </ul>
       </nav>
-      <button class="mobile-menu-btn">☰</button>
+      <!-- The mobile menu toggle button was missing an accessible label. -->
+      <button class="mobile-menu-btn" aria-label="Open main menu">☰</button>
     </div>
   </header>
 

--- a/script.js
+++ b/script.js
@@ -1,12 +1,19 @@
 document.addEventListener('DOMContentLoaded', function() {
   // Mobile menu toggle
-  const mobileMenuBtn = document.getElementById('mobile-menu-btn');
-  const mainNav = document.getElementById('main-nav');
+  // Select the mobile menu button and navigation using the same selectors
+  // that exist in index.html. The original code used element IDs that
+  // weren't present which prevented the mobile navigation from toggling.
+  const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+  const mainNav = document.querySelector('nav ul');
   
   if (mobileMenuBtn && mainNav) {
     mobileMenuBtn.addEventListener('click', () => {
       mainNav.classList.toggle('active');
-      mobileMenuBtn.textContent = mainNav.classList.contains('active') ? '✕' : '☰';
+
+      const isOpen = mainNav.classList.contains('active');
+      mobileMenuBtn.textContent = isOpen ? '✕' : '☰';
+      // Keep the button label accessible for screen readers.
+      mobileMenuBtn.setAttribute('aria-label', isOpen ? 'Close main menu' : 'Open main menu');
     });
   }
   
@@ -140,7 +147,10 @@ document.addEventListener('DOMContentLoaded', function() {
   window.addEventListener('load', animateOnScroll);
   
   // Form submission
-  const contactForm = document.getElementById('contact-form');
+  // Grab the contact form using the class from the markup. The previous
+  // selector looked for an ID that doesn't exist which meant the submit
+  // handler never ran.
+  const contactForm = document.querySelector('.contact-form form');
   if (contactForm) {
     contactForm.addEventListener('submit', (e) => {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- make `script.js` match markup by querying the mobile menu button and navigation by class
- hook contact form submission by querying the form using the existing class
- add `aria-label` for the mobile menu button

## Testing
- `npm test` *(fails: Could not read package.json)*
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68592e78abfc8324b123becdd9ad581a